### PR TITLE
Add docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM jekyll/jekyll:3.4.3
+
+RUN gem install \
+  jekyll \
+  jekyll-menus
+
+VOLUME .:/srv/jekyll
+EXPOSE 4000 80
+
+RUN jekyll -v

--- a/README.txt
+++ b/README.txt
@@ -1,7 +1,32 @@
-Site PHPWomenBR
+## [PHPWomen Br](http://phpwomen.org.br) site
 
-O tema escolhido pelo grupo Arcana by HTML5 UP
+#### Getting Started
+  - Cloning the repository
 
-Sugestões ?
+    ```$ git clone git@github.com:phpwomenbr/site.git ```
+  - Enter into folder
+    ```$ cd site/ ```
 
-Quer dar uma sugestão de mudança? Você também pode abrir um Pull Request com a implementação de sua sugestão =)
+  - Setup the environment
+
+    Use Docker Compose 
+    ```$ docker-compose up --build```
+
+    OR
+
+    Use Docker Run 
+    ```$ docker run -itd -v $(pwd):/srv/jekyll -p 4000:4000 jekyll/jekyll:3.4.3 jekyll serve```
+
+  - Open in browser the default address:
+    http://0.0.0.0:4000/
+
+#### Contribute
+ You can:
+  - Create content such as texts, photos, videos and others and fix previous contents.
+
+## Template
+[Arcana](https://html5up.net/arcana) by [HTML5 UP](https://html5up.net/)
+
+#### License is MIT
+
+

--- a/_config.yml
+++ b/_config.yml
@@ -1,8 +1,10 @@
-name: PHPWomenBR
-description: PHPWomen Brasil
+name: PHPWomen
+sub_name: BR
+email: 'contato@phpwomen.org.br'
+
+title: 'PHPWomenBR'
+description: PHPWomen BR site
 keywords: PHP,women,PHPWomen 
-paginate: 10
 baseurl: ''
----
-gems:
-  - jekyll-menus
+
+plugins_dir: ['jekyll-menus']

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '2'
+services:
+  jekyll:
+    image: jekyll/jekyll:3.4.3
+    command: jekyll serve --watch --incremental
+    ports:
+        - 4000:4000
+    volumes:
+        - .:/srv/jekyll


### PR DESCRIPTION
Allows  to standardize the environment to run the
project without installing local dependencies,
such as Jekyll.

Use the README to follow the instructions.